### PR TITLE
Log item click handling improvements

### DIFF
--- a/src/logs.js
+++ b/src/logs.js
@@ -104,6 +104,8 @@ function addOrUpdateMarker(log, map) {
         marker: map.addMarker(log.coords, {element, icon})
       };
     }
+
+    return key;
   }
 }
 
@@ -381,6 +383,7 @@ function showLogs(logs, map, form) {
           let coords = logItem.dataset.coords.split(',').map((c) => parseFloat(c));
           coords.reverse();
           map.jumpTo(coords);
+          showPopup(markers[key].marker);
         });
       }
       lastSeen = log.timestamp;
@@ -452,6 +455,25 @@ function showLogs(logs, map, form) {
       removeLogFromMarker(key, elId);
     });
   });
+}
+
+// Display one popup and hide the rest
+function showPopup(marker) {
+  closePopups();
+  const popup = marker.getPopup();
+  if (!popup.isOpen()) {
+    marker.togglePopup();
+  }
+}
+
+// Hide all markers
+function closePopups() {
+  for (const marker of Object.values(markers)) {
+    let popup = marker.marker.getPopup();
+    if (popup.isOpen()) {
+      marker.marker.togglePopup();
+    }
+  }
 }
 
 function fadeMarkers() {

--- a/src/map.js
+++ b/src/map.js
@@ -57,9 +57,15 @@ class Map {
   }
 
   jumpTo(coords) {
+    // Only zoom in, never out
+    let zoom = this.map.getZoom();
+    if (zoom < 14) {
+      zoom = 14;
+    }
+
     this.map.jumpTo({
       center: coords,
-      zoom: 14,
+      zoom: zoom,
     });
   }
 }


### PR DESCRIPTION
I've made two changes here that should make it easier to work with many markers in a small location:
	- When you click a log item, the associated marker on the map will now show its popup
	- `jumpTo` will no longer zoom you out if you're zoomed in further than `14`

Let me know if I've missed anything!